### PR TITLE
Add --flatten-output

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,10 @@ USAGE:
     indentex [FLAGS] <path>
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
-    -v, --verbose    Show transpilation progress
+        --flatten-output    Remove all indentation from the output
+    -h, --help              Prints help information
+    -V, --version           Prints version information
+    -v, --verbose           Show transpilation progress
 
 ARGS:
     <path>    Path to a single indentex file or a directory (recursively transpile all indentex files)

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,10 +46,14 @@ fn main() {
             .help("Show transpilation progress")
             .short("v")
             .long("verbose"))
+        .arg(Arg::with_name("flatten-output")
+            .help("Remove all indentation from the output")
+            .long("flatten-output"))
         .get_matches();
 
     let path = Path::new(m.value_of("path").unwrap());
     let verbose = m.is_present("verbose");
+    let flatten_output = m.is_present("flatten-output");
 
     let mut ret_val = ReturnCode::Ok as i32;
 
@@ -73,7 +77,7 @@ fn main() {
     };
 
     let ret_val_transpilation = batch.par_iter()
-        .map(|p| match transpile_file(&p) {
+        .map(|p| match transpile_file(&p, flatten_output) {
             Ok(_) => {
                 if verbose {
                     println!("Transpiling file '{}'... {}",

--- a/src/transpile.rs
+++ b/src/transpile.rs
@@ -41,7 +41,7 @@ fn scan_indents<T: AsRef<str>>(lines: &[T]) -> Vec<usize> {
 
 
 // Transpilation
-fn transpile<T: AsRef<str>>(lines: &[T]) -> String {
+fn transpile<T: AsRef<str>>(lines: &[T], flatten_output: bool) -> String {
     use parsers::Environment;
     use parsers::Hashline::{PlainLine, OpenEnv};
     use parsers::process_line;
@@ -71,7 +71,11 @@ fn transpile<T: AsRef<str>>(lines: &[T]) -> String {
                 tag_begin
             }
         };
-        transpiled.push_str(&tl);
+        if flatten_output {
+            transpiled.push_str(&tl.trim_left());
+        } else {
+            transpiled.push_str(&tl);
+        }
         transpiled.push_str(LINESEP);
 
         // Check if we are in an environment and close as many as needed
@@ -81,7 +85,11 @@ fn transpile<T: AsRef<str>>(lines: &[T]) -> String {
         } {
             // `unwrap()` is safe here since we have already checked if the stack is empty
             let tag_end = env_stack.pop().unwrap().latex_end();
-            transpiled.push_str(&tag_end);
+            if flatten_output {
+                transpiled.push_str(&tag_end.trim_left());
+            } else {
+                transpiled.push_str(&tag_end);
+            }
             transpiled.push_str(LINESEP);
         }
     }
@@ -89,11 +97,11 @@ fn transpile<T: AsRef<str>>(lines: &[T]) -> String {
     transpiled
 }
 
-pub fn transpile_file<T: AsRef<Path>>(path: T) -> Result<(), IndentexError> {
+pub fn transpile_file<T: AsRef<Path>>(path: T, flatten_output: bool) -> Result<(), IndentexError> {
     use file_utils::{read_and_trim_lines, rename_indentex_file, write_to_file};
 
     let lines = read_and_trim_lines(path.as_ref())?;
-    let transpiled_text = transpile(&lines);
+    let transpiled_text = transpile(&lines, flatten_output);
     let path_out = rename_indentex_file(path)?;
     write_to_file(path_out, &transpiled_text)?;
 


### PR DESCRIPTION
Quick and dirty implementation for #6.

Add a `--flatten-output` command line argument that left trims all lines during transpilation.