### PR TITLE
Use term_painter instead of ansi_term

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,12 +2,12 @@
 name = "indentex"
 version = "0.4.0"
 dependencies = [
- "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.24.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "globset 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ignore 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term-painter 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -200,6 +200,23 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "term"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "term-painter"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "term 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "term_size"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,6 +322,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum regex-syntax 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9191b1f57603095f105d317e375d19b1c9c5c3185ea9633a99a6dcbed04457"
 "checksum same-file 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d931a44fdaa43b8637009e7632a02adc4f2b2e0733c08caa4cf00e8da4a117a7"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
+"checksum term 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d168af3930b369cfe245132550579d47dfd873d69470755a19c2c6568dbbd989"
+"checksum term-painter 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ab900bf2f05175932b13d4fc12f8ff09ef777715b04998791ab2c930841e496b"
 "checksum term_size 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2b6b55df3198cc93372e85dd2ed817f0e38ce8cc0f22eb32391bfad9c4bf209"
 "checksum thread-id 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8df7875b676fddfadffd96deea3b1124e5ede707d4884248931077518cf1f773"
 "checksum thread_local 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c85048c6260d17cf486ceae3282d9fb6b90be220bf5b28c400f5485ffc29f0c7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,12 @@ publish = false
 
 
 [dependencies]
-ansi_term = "^0.9.0"
 clap = "^2.24.2"
 globset = "^0.2.0"
 ignore = "^0.2.0"
 nom = "^3.0.0"
 rayon = "^0.7.0"
+term-painter = "^0.2.3"
 
 
 [profile.release]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-extern crate ansi_term;
 #[macro_use]
 extern crate clap;
 extern crate globset;
@@ -6,6 +5,7 @@ extern crate ignore;
 #[macro_use]
 extern crate nom;
 extern crate rayon;
+extern crate term_painter;
 
 // Import helper macros before `parsers`
 #[macro_use]
@@ -24,13 +24,14 @@ enum ReturnCode {
 }
 
 fn main() {
-    use ansi_term::Colour::{Red, Green};
     use clap::{App, Arg};
     use file_utils::walk_indentex_files;
     use rayon::prelude::*;
     use std::cmp;
     use std::path::{Path, PathBuf};
     use std::process;
+    use term_painter::Color::{Green, Red};
+    use term_painter::ToStyle;
     use transpile::{transpile_file, TranspileOptions};
 
     let m = App::new("indentex")


### PR DESCRIPTION
For better Windows-compatibility, we should use [term_painter](https://crates.io/crates/term-painter) instead of ansi_term. It works for Linux terminals, Windows PowerShell and Windows Command Prompt. `term_painter` is also largely api-compatible with `ansi_term` so no actual code changes were made in this PR.

Working towards #17 

I've also tested [termcolor](https://crates.io/crates/termcolor) but its API is [pretty verbose](https://github.com/syxolk/indentex/commit/963da790b05c96d6705e6631d95f3d0c1a8f0750) and it seems to have issues with rayon's multithreading (it panics).